### PR TITLE
Update micromouse rules

### DIFF
--- a/labirinto_es.md
+++ b/labirinto_es.md
@@ -18,13 +18,13 @@ Dispondrá de 5 minutos para reconocer el laberinto y 3 intentos para completarl
 
 ![Imagen del labirinto](img/maze_finish_line.jpg)
 
-1. El laberinto está formado por un área de ~~13 por 13~~ **16 por 16** celdas, que vienen siendo estancias de forma cuadrada y adyacentes por cada uno de sus lados del perímetro de la propia celda.
+1. El laberinto está formado por un área de 16 por 16 celdas, que vienen siendo estancias de forma cuadrada y adyacentes por cada uno de sus lados del perímetro de la propia celda.
 
-2. Cada celda tiene un tamaño de ~~150 por 150~~ **180 por 180** milímetros, y sobre cada uno de los lados de la celda puede existir, o no, una pared que no dejará pasar al robot por ese lateral.
+2. Cada celda tiene un tamaño de 180 por 180 milímetros, y sobre cada uno de los lados de la celda puede existir, o no, una pared que no dejará pasar al robot por ese lateral.
 
-3. Las paredes del laberinto tienen una altura de ~~100mm~~ **50mm**, un grosor de ~~20mm~~ **12mm** y van situadas sobre el medio y medio de las celdas que separa.
+3. Las paredes del laberinto tienen una altura de 50mm, un grosor de 12mm y van situadas sobre el medio y medio de las celdas que separa.
 
-4. Hay que tener en cuenta que una pared invade el espacio de las dos celdas y reducen el área de cada celda, achicándola ~~10mm~~ **6mm** por el lado de la pared y, por lo tanto, dejando los corredores por los que tiene que pasar el robot en ~~130mm~~ **168mm** de ancho.
+4. Hay que tener en cuenta que una pared invade el espacio de las dos celdas y reducen el área de cada celda, achicándola 6mm por el lado de la pared y, por lo tanto, dejando los corredores por los que tiene que pasar el robot en 168mm de ancho.
 
 5. Se asume un 5% de tolerancia en todas las dimensiones dadas.
 
@@ -32,7 +32,7 @@ Dispondrá de 5 minutos para reconocer el laberinto y 3 intentos para completarl
 
 7. Los lados de las paredes son de color blanco, la parte superior de las paredes es de color naranja y el suelo es de color negro. Las partes del laberinto son de madera, acabada con pintura mate.
 
-8. Debe asumirse que las tonalidades y acabados de la pintura puedan variar a lo largo del recorrido, existir zonas de sombras por la iluminación ambiental y variaciones en la cantidad de fricción que ofrece el suelo. Las columnas que sujetan las divisiones son de ~~aluminio extruído~~ **madera**, y quedan a la vista del robot.
+8. Debe asumirse que las tonalidades y acabados de la pintura puedan variar a lo largo del recorrido, existir zonas de sombras por la iluminación ambiental y variaciones en la cantidad de fricción que ofrece el suelo. Las columnas que sujetan las divisiones son de madera, y quedan a la vista del robot.
 
 9. En el suelo puede existir la unión de tableros de madera que podrían provocar un pequeño desnivel que se tratará de minimizar para evitar que los robots puedan ser afectados.
 
@@ -40,7 +40,7 @@ Dispondrá de 5 minutos para reconocer el laberinto y 3 intentos para completarl
 
 11. El punto de llegada o “meta” está situado en el centro del laberinto.
 
-12. La meta está compuesta de un área de ~~3 por 3~~ **2 por 2** celdas con paredes sólo en su perímetro excepto en la entrada, que será tan sólo de una pared en una celda y que se denomina “puerta de meta”.
+12. La meta está compuesta de un área de 2 por 2 celdas con paredes sólo en su perímetro excepto en la entrada, que será tan sólo de una pared en una celda y que se denomina “puerta de meta”.
 
 13. La zona de meta tendrá una marca en el suelo que indicar al robot la zona de llegada.
 Dicha marca será una línea blanca de 2cm de grosor.
@@ -53,7 +53,7 @@ Dicha marca será una línea blanca de 2cm de grosor.
 
 2. El funcionamiento del robot debe ser completamente autónomo. Se puede utilizar cualquier método de control, siempre y cuando esté integrado enteramente en el robot y no reciba señales o indicaciones externas (de cualquier tipo).
 
-3. ~~No existe limitación en cuanto a masa, dimensiones o geometría del robot, con la única excepción de la altura, que no debe superar, en ningún caso, los 95mm.~~ **Se recomienda que las dimensiones del robot no superen los 16cm de ancho por 16cm de largo. Si cambian de geometría no deberían rebasar estas dimensiones. No existe limitación en cuanto a la altura del robot.** El robot debe ser una única unidad indivisible.
+3. Se recomienda que las dimensiones del robot no superen los 16cm de ancho por 16cm de largo. Si cambian de geometría no deberían rebasar estas dimensiones. No existe limitación en cuanto a la altura del robot. El robot debe ser una única unidad indivisible.
 
 4. El robot no podrá saltar por encima, sobrevolar, escalar, cortar, rascar, quemar, dañar o destruir las paredes del laberinto.
 5. El robot debe tener un nombre o número con fines de registro y seguimiento. El robot debe mostrar este nombre o número para permitir su identificación a la organización y jueces y a los espectadores.
@@ -91,7 +91,7 @@ Dicha marca será una línea blanca de 2cm de grosor.
 
 12. En caso de colisión con las paredes del laberinto o detención del robot por más de 10 segundos sin que este tenga intención de moverse o de progresión en el recorrido, se perderá el intento en curso.
 
-13. El tiempo a tener en cuenta para la competición con otros robots será el menor de los tiempos en completar adecuadamente el recorrido del laberinto.   
+13. El tiempo a tener en cuenta para la competición con otros robots será el menor de los tiempos en completar adecuadamente el recorrido del laberinto.
 
 ### Ganadores de la competición
 
@@ -109,7 +109,7 @@ Otras personas pueden estar identificadas como “juez asistente” y ayudarán 
 
 Las decisiones finales siempre las toma el juez principal.
 
-### Recursos de interés 
+### Recursos de interés
 
   * [Repositorio para la generación de laberintos](https://github.com/brico-labs/OshwdemMazes)
   * [Solving a Maze](https://www.cs.bu.edu/teaching/alg/maze/)

--- a/labirinto_es.md
+++ b/labirinto_es.md
@@ -36,7 +36,7 @@ Dispondrá de 5 minutos para reconocer el laberinto y 3 intentos para completarl
 
 9. En el suelo puede existir la unión de tableros de madera que podrían provocar un pequeño desnivel que se tratará de minimizar para evitar que los robots puedan ser afectados.
 
-10. El punto de partida o “salida” está situado en una de las cuatro esquinas del laberinto.
+10. El punto de partida o “salida” está situado en una de las cuatro esquinas del laberinto. La salida está orientada de manera que cuando la pared libre se encuentra al "norte", las paredes de contorno del laberinto se encuentran al "oeste" y "sur". Es decir, el robot sale en sentido de las agujas del reloj.
 
 11. El punto de llegada o “meta” está situado en el centro del laberinto.
 

--- a/labirinto_gl.md
+++ b/labirinto_gl.md
@@ -20,19 +20,19 @@ tempo que poida. Gañará a competición o robot que complete o percorrido no me
 
 ![Imaxe do labirinto](img/maze_finish_line.jpg)
 
-1. O labirinto está formado por unha área de ~~13 por 13~~ **16 por 16** celas, que veñen sendo estancias
+1. O labirinto está formado por unha área de 16 por 16 celas, que veñen sendo estancias
 de forma cadrada e adxacentes por cada un dos catro lados do perímetro da propia
 cela.
 
-2. Cada cela ten un tamaño de ~~150 por 150~~ **180 por 180** milímetros, e sobre cada un dos lados da cela
+2. Cada cela ten un tamaño de 180 por 180 milímetros, e sobre cada un dos lados da cela
 pode existir, ou non, unha parede que non deixará pasar o robot por ese lateral.
 
-3. As paredes do labirinto teñen unha altura de ~~100mm~~ **50mm**, un grosor de ~~20mm~~ **12mm** e van
+3. As paredes do labirinto teñen unha altura de 50mm, un grosor de 12mm e van
 situadas sobre o medio e medio das celas que separa.
 
 4. Hai que ter en conta que unha parede invade o espazo das dúas celas e reducen a área
-de cada cela achicándoa ~~10mm~~ **6mm** polo lado da parede e, polo tanto, deixando os
-corredores polos que ten que pasar o robot en ~~130mm~~ **168mm** de ancho.
+de cada cela achicándoa 6mm polo lado da parede e, polo tanto, deixando os
+corredores polos que ten que pasar o robot en 168mm de ancho.
 
 5. Asúmese un 5% de tolerancia en tódalas dimensións dadas.
 
@@ -46,7 +46,7 @@ pintura mate.
 8. Debe asumirse que as tonalidades e remates da pintura poden variar ó longo do
 percorrido, existir zonas de sombras pola iluminación ambiental e variacións na
 cantidade de fricción que ofrece o chan. As columnas que soportan las paredes son de
-~~aluminio extruído~~ **madeira**, e quedan á vista do robot.
+madeira, e quedan á vista do robot.
 
 9. No chan pode existir a unión de taboleiros de madeira que poderían provocar un
 pequeno desnivel ou focha que se tratará de minimizar para evitar que os robots
@@ -55,8 +55,8 @@ poidan ser afectados.
 10. O punto de partida ou “saída” está situado en unha das catro esquinas do labirinto.
 
 11. O punto de chegada ou “meta” está situado no centro do labirinto.
- 
-12. A meta está composta dunha área de ~~3 por 3~~ **2 por 2** celas con paredes só no seu perímetro,
+
+12. A meta está composta dunha área de 2 por 2 celas con paredes só no seu perímetro,
 agás na entrada que será tan só dunha parede nunha cela e que se denomina "porta de
 meta".
 
@@ -77,8 +77,7 @@ tecnoloxías abertas.
 calquera método de control, sempre e cando estea integrado enteiramente no robot e
 non reciba sinais oi indicacións externas (de calquera tipo).
 
-3. ~~Non existe limitación en canto a masa, dimensións ou xeometría do robot, coa única
-excepción da altura, que non debe superar, en ningún caso, os 95mm.~~ **Recoméndase que o robot non supere os 16cm de ancho por 16cm de largo. Se cambian de xeometría no deberían superar estas dimensións. Non existe limitación na altura do robot.** O robot debe ser unha única unidade indivisíbel.
+3. Recoméndase que o robot non supere os 16cm de ancho por 16cm de largo. Se cambian de xeometría no deberían superar estas dimensións. Non existe limitación na altura do robot. O robot debe ser unha única unidade indivisíbel.
 
 4. O robot non poderá saltar por riba, sobrevoar, escalar, cortar, rascar, queimar, danar ou
 destruír as paredes do labirinto.
@@ -119,7 +118,7 @@ seguintes operacións:
     2. Axuste manual dos sensores ou dos elementos motrices do robot.
     3. Substitución das baterías.
     4. Facer reparacións de pezas danadas ou substituílas por outras que teñen similares características que a peza danada.
-    
+
 7. Dentro do tempo de recoñecemento do labirinto, o robot que consiga entrar á zona de
 meta poderá seguir operativo ou continuar explorando o labirinto até que finalice o
 tempo establecido.
@@ -140,7 +139,7 @@ segundos sen que este teña intención de movemento ou de progresión no percorr
 se perderá o intento en curso.
 
 13. O tempo a ter en conta para a competición cos outros robots será o menor dos tempos
-en completar axeitadamente o percorrido do labirinto.    
+en completar axeitadamente o percorrido do labirinto.
 
 ### Gañadores da competición
 
@@ -169,7 +168,7 @@ participante a un xuíz asistente.
 
 As decisións finais sempre as tomará o xuíz principal.
 
-### Recursos de interese 
+### Recursos de interese
 
   * [Repositorio para a xeración de labirintos](https://github.com/brico-labs/OshwdemMazes)
   * [Solving a Maze](https://www.cs.bu.edu/teaching/alg/maze/)


### PR DESCRIPTION
- Remove references to the old rules (non-international rules).
- Update documentation on the start cell orientation, according to the international rules and to the [latest changes in OshwdemMazes](https://github.com/brico-labs/OshwdemMazes/pull/2).

**Missing translation to Galician**... If someone could help, I would gladly amend the changes to the last commit. :innocent: 

Text to translate:

> La salida está orientada de manera que cuando la pared libre se encuentra al "norte", las paredes de contorno del laberinto se encuentran al "oeste" y "sur". Es decir, el robot sale en sentido de las agujas del reloj.